### PR TITLE
Only use one Python version specifier in CI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,7 +19,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
+        with:
+          python-version-file: "pyproject.toml"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version-file: "pyproject.toml"
 
       - name: 🔨 Install dependencies
         run: uv sync --no-default-groups --group test


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Modify GitHub Actions workflows to dynamically read Python version from pyproject.toml instead of hardcoding version 3.11